### PR TITLE
ODY-386 キーボード表示時の要素縮小化

### DIFF
--- a/components/forest/Main.tsx
+++ b/components/forest/Main.tsx
@@ -1,7 +1,7 @@
-import { ScrollView, StyleSheet, useWindowDimensions, FlatList } from 'react-native';
+import { ScrollView, StyleSheet, useWindowDimensions, FlatList, Keyboard } from 'react-native';
 
 import { View } from 'react-native';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import ArrowButton from '../leaf/ArrowButton';
 import MainCardWithInput from '../tree/MainCardWithInput';
 import PriceContext from './PriceContext';
@@ -28,6 +28,21 @@ export default function Main() {
   const { width } = useWindowDimensions();
   const flatListRef = useRef<FlatList<SlideType>>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [keyboardActive, setKeyboardActive] = useState(false);
+
+  useEffect(() => {
+    const showSubscription = Keyboard.addListener('keyboardDidShow', () => {
+      setKeyboardActive(true);
+    });
+    const hideSubscription = Keyboard.addListener('keyboardDidHide', () => {
+      setKeyboardActive(false);
+    });
+
+    return () => {
+      showSubscription.remove();
+      hideSubscription.remove();
+    };
+  }, []);
 
   const _renderItem = ({ item }: { item: SlideType }) => {
     const getMainCard = () => {
@@ -43,7 +58,7 @@ export default function Main() {
     return (
       <View style={StyleSheet.create({ cardContainer: { width: width } }).cardContainer}>
         <ScrollView contentContainerStyle={{ flexGrow: 1 }} keyboardShouldPersistTaps='handled' scrollEnabled={false}>
-          <View style={styles.container}>
+          <View style={[styles.container, keyboardActive && styles.contentScaled]}>
             <ArrowButton direction='left' onClick={scrollToPreviousSlide} />
             {getMainCard()}
             <ArrowButton direction='right' onClick={scrollToNextSlide} />
@@ -99,5 +114,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     paddingVertical: 15,
     paddingHorizontal: 45,
+  },
+  contentScaled: {
+    transform: [{ scale: 0.7 }, { translateY: -145 }],
   },
 });


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] ビルドエラー/ESLint エラーは起きていないか
- [x] [開発ルール](https://daydule.atlassian.net/wiki/spaces/DAYDULE/pages/9765029)を守って実装しているか
- [x] 単体テストが全て OK になっているか
- [x] 機密情報を含んでいないか
- [x] 最新の`develop`ブランチを反映しているか

# レビュー優先度（どれか一つ）

- [ ] すぐ見てもらいたい
- [x] 3 日くらいで見てもらいたい
- [ ] 7 日くらいで見てもらいたい

# レビューの度合い

- [ ] コードをぱっと確認してもらいたい
- [x] コードをぱっと確認 & 動作確認してもらいたい
- [ ] コードをしっかり確認 & 動作確認してもらいたい

# レビュワーによる動作確認

- [ ] @atoook 
- [ ] @Mellbrother 
- [x] @tom-takeru 

# やったこと<!-- このプルリクエストでやったことを書く -->
キーボードが表示された際に入力欄が隠れてしまっていたので、キーボード表示時には要素が縮小されるように修正

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->
特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->
KeyboardAvoidingViewを利用した修正を試みたのですが、KeyboardAvoidingViewはコンテンツをキーボードが表示されたときに適切に移動させるために設計されていて、要素の縦横比を維持しながら全体を縮小する機能は提供されていないっぽいので自前で実装してみました。

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->
特になし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - キーボードがアクティブなときにコンテンツのスケーリングを調整するためのキーボードイベントの処理を追加しました。これにより、キーボードによる遮蔽なくコンテンツを縮小して、ユーザーエクスペリエンスが向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->